### PR TITLE
fix c header file for bulletproof rewind

### DIFF
--- a/_cffi_build/secp256k1_bulletproofs.h
+++ b/_cffi_build/secp256k1_bulletproofs.h
@@ -46,7 +46,6 @@ int secp256k1_bulletproof_rangeproof_verify_multi(
 
 int secp256k1_bulletproof_rangeproof_rewind(
     const secp256k1_context* ctx,
-    const secp256k1_bulletproof_generators* gens,
     uint64_t* value,
     unsigned char* blind,
     const unsigned char* proof,


### PR DESCRIPTION
function signature for secp256k1_bulletproof_rangeproof_rewind had changed, causing cffi build error.

update it.

